### PR TITLE
Gc.set now changes the minor heap size of all domains

### DIFF
--- a/Changes
+++ b/Changes
@@ -64,6 +64,11 @@ Working version
   (Enguerrand Decorne, report by Jon Ludlam,
   review by Tom Kelly, KC Sivaramakrishnan and Gabriel Scherer)
 
+- #11082, #???: Changing the minor heap size via Gc.set applies
+  to all domains.
+  (Sabine Schmaltz, Gabriel Scherer, review by Xavier Leroy,
+  KC Sivaramakrishnan, Enguerrand Decorne, Tom Kelly, ???)
+
 ### Code generation and optimizations:
 
 - #10972: ARM64 multicore support: OCaml & C stack separation;

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -35,9 +35,10 @@ extern "C" {
      (uintnat)(dom_st)->young_ptr < \
      atomic_load_explicit(&((dom_st)->young_limit), memory_order_relaxed)))
 
-asize_t caml_norm_minor_heap_size (intnat);
-int caml_reallocate_minor_heap(asize_t);
-void caml_update_minor_heap_max(uintnat minor_heap_wsz);
+asize_t caml_norm_minor_heap_wsize (intnat);
+void caml_stw_resize_minor_heaps(caml_domain_state*, void*, int,
+                                     caml_domain_state**);
+void caml_check_minor_heap();
 
 /* is there a STW interrupt queued that needs servicing */
 int caml_incoming_interrupts_queued(void);
@@ -60,10 +61,10 @@ CAMLextern void (*caml_atfork_hook)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 
-CAMLextern void caml_init_domains(uintnat minor_heap_wsz);
+CAMLextern void caml_init_domains();
 CAMLextern void caml_init_domain_self(int);
 
-CAMLextern uintnat caml_minor_heap_max_wsz;
+CAMLextern uintnat caml_minor_heap_wsz;
 
 CAMLextern atomic_uintnat caml_num_domains_running;
 CAMLextern uintnat caml_minor_heaps_start;

--- a/runtime/caml/domain_state.tbl
+++ b/runtime/caml/domain_state.tbl
@@ -98,8 +98,6 @@ DOMAIN_STATE(uintnat, requested_external_interrupt)
 DOMAIN_STATE(int, parser_trace)
 /* See parsing.c */
 
-DOMAIN_STATE(asize_t, minor_heap_wsz)
-
 DOMAIN_STATE(struct caml_heap_state*, shared_heap)
 
 DOMAIN_STATE(int, id)

--- a/runtime/caml/minor_gc.h
+++ b/runtime/caml/minor_gc.h
@@ -25,7 +25,6 @@
 #define caml_young_limit Caml_state->young_limit
 #define caml_young_alloc_start Caml_state->young_start
 #define caml_young_alloc_end Caml_state->young_end
-#define caml_minor_heap_wsz Caml_state->minor_heap_wsz
 
 
 #define CAML_TABLE_STRUCT(t) { \
@@ -62,7 +61,7 @@ struct caml_minor_tables {
 CAMLextern void caml_minor_collection (void);
 
 #ifdef CAML_INTERNALS
-extern void caml_set_minor_heap_size (asize_t); /* size in bytes */
+extern void caml_set_minor_heap_wsz (asize_t);
 extern void caml_empty_minor_heap_no_major_slice_from_stw
   (caml_domain_state* domain, void* unused, int participating_count,
     caml_domain_state** participating); /* in STW */

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -105,7 +105,7 @@ CAMLexport value caml_alloc_custom_mem(const struct custom_operations * ops,
        [heap_size / 150] is really [heap_size * (2/3) / 100] (but faster). */
     caml_heap_size(Caml_state->shared_heap) / 150 * caml_custom_major_ratio;
   mlsize_t max_minor =
-    Bsize_wsize (Caml_state->minor_heap_wsz) / 100 * caml_custom_minor_ratio;
+    Bsize_wsize (caml_minor_heap_wsz) / 100 * caml_custom_minor_ratio;
   value v = alloc_custom_gen (ops, bsz, mem, max_major, mem_minor, max_minor);
   return v;
 }

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -146,10 +146,6 @@ struct dom_internal {
   atomic_uintnat backup_thread_msg;
   caml_plat_mutex domain_lock;
   caml_plat_cond domain_cond;
-
-  /* modified only during STW sections */
-  uintnat minor_heap_area_start;
-  uintnat minor_heap_area_end;
 };
 typedef struct dom_internal dom_internal;
 
@@ -192,21 +188,26 @@ CAMLexport atomic_uintnat caml_num_domains_running;
 
 
 
-/* size of the virtual memory reservation for the minor heap, per domain */
-uintnat caml_minor_heap_max_wsz;
+/* size of the minor heap, per domain. Only modified during STW. */
+uintnat caml_minor_heap_wsz;
 /*
-  The amount of memory reserved for all minor heaps of all domains is
-  Max_domains * caml_minor_heap_max_wsz. Individual domains can allocate
-  smaller minor heaps, but when a domain calls Gc.set to allocate a bigger minor
-  heap than this reservation, we perform a new virtual memory reservation based
-  on the increased minor heap size.
+  The amount of memory reserved for all minor heaps of all domains
+  is Max_domains * caml_minor_heap_wsz.
 
-  New domains are created with a minor heap of size
-  caml_params->init_minor_heap_wsz.
+  When a domain calls Gc.set to request a new minor heap size for all domains,
+  we enter a STW-section:
 
-  To perform a new virtual memory reservation for the heaps, we stop the world
-  and do a minor collection on all domains.
-  See [stw_resize_minor_heap_reservation].
+  1. perform a minor collection on all domains,
+  2. all active domains free their minor heap,
+  3. drop the minor heap reservation and reserve a new minor heap area
+  for Max_domains domains,
+  4. all active domains allocate their minor heap with the requested size.
+  See [caml_stw_resize_minor_heaps].
+
+  New domains are created with minor heaps of size of caml_minor_heap_wsz.
+
+  INVARIANT: only active domains have a minor heap allocated (committed).
+  When a domain terminates, we free the minor heap.
 */
 
 CAMLexport uintnat caml_minor_heaps_start;
@@ -366,7 +367,7 @@ void caml_domain_set_name(char *name)
   caml_thread_setname(thread_name);
 }
 
-asize_t caml_norm_minor_heap_size (intnat wsize)
+asize_t caml_norm_minor_heap_wsize (intnat wsize)
 {
   asize_t bs;
   if (wsize < Minor_heap_min) wsize = Minor_heap_min;
@@ -378,30 +379,21 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
 /* The current minor heap layout is as follows:
 
 - A contiguous memory block of size
-   [caml_minor_heap_max_wsz * Max_domains]
+   [caml_minor_heap_wsz * Max_domains]
   is reserved by [caml_init_domains]. The boundaries
   of this reserved area are stored in the globals
     [caml_minor_heaps_start]
   and
     [caml_minor_heaps_end].
 
-- Each domain gets a reserved section of this block
-  of size [caml_minor_heap_max_wsz], whose boundaries are stored as
-    [domain_self->minor_heap_area_start]
-  and
-    [domain_self->minor_heap_area_end]
-
-  These variables accessed in [stw_resize_minor_heap_reservation],
-  synchronized by a global barrier.
-
-- Each domain then commits a segment of size
-    [domain_state->minor_heap_wsz]
+- Every active domain i commits a segment of size
+    [caml_minor_heap_wsz]
   starting at
-    [domain_state->minor_heap_area_start]
-  that it actually uses.
+    [caml_minor_heaps_start + i * caml_minor_heap_wsz]
+  to allocate its minor heap (see [get_domain_minor_heap_area_start]).
 
   This is done below in
-    [caml_reallocate_minor_heap]
+    [allocate_minor_heap]
   which is called both at domain-initialization (by [create_domain])
   and if a request comes to change the minor heap size.
 
@@ -414,8 +406,16 @@ asize_t caml_norm_minor_heap_size (intnat wsize)
   domain, so they need no synchronization.
 */
 
-Caml_inline void check_minor_heap() {
+Caml_inline uintnat get_domain_minor_heap_area_start(int domain_id) {
+  uintnat minor_heap_max_bsz = (uintnat)Bsize_wsize(caml_minor_heap_wsz);
+
+  return caml_minor_heaps_start + minor_heap_max_bsz * (uintnat)domain_id;
+}
+
+void caml_check_minor_heap() {
   caml_domain_state* domain_state = Caml_state;
+  uintnat minor_heap_area_start =
+    get_domain_minor_heap_area_start(domain_state->id);
   CAMLassert(domain_state->young_ptr == domain_state->young_end);
 
   caml_gc_log("young_start: %p, young_end: %p, minor_heap_area_start: %p,"
@@ -423,34 +423,39 @@ Caml_inline void check_minor_heap() {
       ARCH_SIZET_PRINTF_FORMAT "u words",
       domain_state->young_start,
       domain_state->young_end,
-      (value*)domain_self->minor_heap_area_start,
-      (value*)domain_self->minor_heap_area_end,
-      domain_state->minor_heap_wsz);
+      (value*)minor_heap_area_start,
+      (value*)(minor_heap_area_start + caml_minor_heap_wsz),
+      caml_minor_heap_wsz);
   CAMLassert(
     (/* uninitialized minor heap */
       domain_state->young_start == NULL
       && domain_state->young_end == NULL)
     ||
     (/* initialized minor heap */
-      domain_state->young_start == (value*)domain_self->minor_heap_area_start
-      && domain_state->young_end <= (value*)domain_self->minor_heap_area_end));
+      domain_state->young_start == (value*)minor_heap_area_start
+      && domain_state->young_end <= (value*)(minor_heap_area_start
+                                             + caml_minor_heap_wsz))
+  );
 }
 
 static void free_minor_heap() {
   caml_domain_state* domain_state = Caml_state;
+  asize_t minor_heap_wsz = domain_state->young_end - domain_state->young_start;
+  uintnat minor_heap_area_start =
+    get_domain_minor_heap_area_start(domain_state->id);
 
   caml_gc_log ("trying to free old minor heap: %"
         ARCH_SIZET_PRINTF_FORMAT "uk words",
-        domain_state->minor_heap_wsz / 1024);
+        minor_heap_wsz / 1024);
 
-  check_minor_heap();
+  caml_check_minor_heap();
 
   /* free old minor heap.
      instead of unmapping the heap, we decommit it, so there's
      no race whereby other code could attempt to reuse the memory. */
   caml_mem_decommit(
-      (void*)domain_self->minor_heap_area_start,
-      domain_state->minor_heap_wsz);
+      (void*)minor_heap_area_start,
+      minor_heap_wsz);
 
   domain_state->young_start =
     domain_state->young_end =
@@ -461,49 +466,43 @@ static void free_minor_heap() {
 
 static int allocate_minor_heap(asize_t wsize) {
   caml_domain_state* domain_state = Caml_state;
+  uintnat minor_heap_area_start =
+    get_domain_minor_heap_area_start(domain_state->id);
 
-  check_minor_heap();
+  caml_check_minor_heap();
 
-  wsize = caml_norm_minor_heap_size(wsize);
+  wsize = caml_norm_minor_heap_wsize(wsize);
 
-  CAMLassert (wsize <= caml_minor_heap_max_wsz);
+  CAMLassert (wsize <= caml_minor_heap_wsz);
 
   caml_gc_log ("trying to allocate minor heap: %"
                ARCH_SIZET_PRINTF_FORMAT "uk words", wsize / 1024);
 
   if (!caml_mem_commit(
-          (void*)domain_self->minor_heap_area_start, Bsize_wsize(wsize))) {
+          (void*)minor_heap_area_start, Bsize_wsize(wsize))) {
     return -1;
   }
 
 #ifdef DEBUG
   {
-    uintnat* p = (uintnat*)domain_self->minor_heap_area_start;
+    uintnat* p = (uintnat*)minor_heap_area_start;
     for (;
-      p < (uintnat*)(domain_self->minor_heap_area_start + Bsize_wsize(wsize));
+      p < (uintnat*)(minor_heap_area_start + Bsize_wsize(wsize));
       p++) {
       *p = Debug_free_minor;
     }
   }
 #endif
 
-  domain_state->minor_heap_wsz = wsize;
-
-  domain_state->young_start = (value*)domain_self->minor_heap_area_start;
+  domain_state->young_start = (value*)minor_heap_area_start;
   domain_state->young_end =
-      (value*)(domain_self->minor_heap_area_start + Bsize_wsize(wsize));
+      (value*)(minor_heap_area_start + Bsize_wsize(wsize));
   atomic_store_rel(&domain_state->young_limit,
                    (uintnat) domain_state->young_start);
   domain_state->young_ptr = domain_state->young_end;
 
-  check_minor_heap();
+  caml_check_minor_heap();
   return 0;
-}
-
-int caml_reallocate_minor_heap(asize_t wsize)
-{
-  free_minor_heap();
-  return allocate_minor_heap(wsize);
 }
 
 /* This variable is owned by [all_domains_lock]. */
@@ -531,7 +530,7 @@ static uintnat fresh_domain_unique_id(void) {
 }
 
 /* must be run on the domain's thread */
-static void create_domain(uintnat initial_minor_heap_wsize) {
+static void create_domain() {
   dom_internal* d = 0;
   caml_domain_state* domain_state;
   struct interruptor* s;
@@ -605,8 +604,13 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     goto init_signal_stack_failure;
   }
 
-  /* the minor heap will be initialized by
-     [caml_reallocate_minor_heap] below. */
+  /* There is no minor heap allocated at this point, either because
+     a) this is a fresh domain, or
+     b) we freed the minor heap of the reused domain slot
+        on [domain_terminate()].
+     Technically, we only need to set the young pointers for a fresh
+     domain, as the reused domain slot will have them set to NULL by
+     [free_minor_heap()] already. */
   domain_state->young_start =
     domain_state->young_end =
     domain_state->young_ptr = NULL;
@@ -625,8 +629,8 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
     goto init_major_gc_failure;
   }
 
-  if(caml_reallocate_minor_heap(initial_minor_heap_wsize) < 0) {
-    goto reallocate_minor_heap_failure;
+  if(allocate_minor_heap(caml_minor_heap_wsz) < 0) {
+    goto allocate_minor_heap_failure;
   }
 
   domain_state->dls_root = Val_unit;
@@ -688,7 +692,7 @@ static void create_domain(uintnat initial_minor_heap_wsize) {
 alloc_main_stack_failure:
 create_stack_cache_failure:
   caml_remove_generational_global_root(&domain_state->dls_root);
-reallocate_minor_heap_failure:
+allocate_minor_heap_failure:
   caml_teardown_major_gc();
 init_major_gc_failure:
   caml_teardown_shared_heap(d->state->shared_heap);
@@ -717,16 +721,15 @@ CAMLexport void caml_reset_domain_lock(void)
 }
 
 /* minor heap initialization and resizing */
-
 static void reserve_minor_heaps() {
   void* heaps_base;
   uintnat minor_heap_reservation_bsize;
   uintnat minor_heap_max_bsz;
 
-  CAMLassert (caml_mem_round_up_pages(Bsize_wsize(caml_minor_heap_max_wsz))
-          == Bsize_wsize(caml_minor_heap_max_wsz));
+  CAMLassert (caml_mem_round_up_pages(Bsize_wsize(caml_minor_heap_wsz))
+          == Bsize_wsize(caml_minor_heap_wsz));
 
-  minor_heap_max_bsz = (uintnat)Bsize_wsize(caml_minor_heap_max_wsz);
+  minor_heap_max_bsz = (uintnat)Bsize_wsize(caml_minor_heap_wsz);
   minor_heap_reservation_bsize = minor_heap_max_bsz * Max_domains;
 
   /* reserve memory space for minor heaps */
@@ -740,19 +743,6 @@ static void reserve_minor_heaps() {
 
   caml_gc_log("new minor heap reserved from %p to %p",
               (value*)caml_minor_heaps_start, (value*)caml_minor_heaps_end);
-
-  for (int i = 0; i < Max_domains; i++) {
-    struct dom_internal* dom = &all_domains[i];
-
-    uintnat domain_minor_heap_area = caml_minor_heaps_start +
-      minor_heap_max_bsz * (uintnat)i;
-
-    dom->minor_heap_area_start = domain_minor_heap_area;
-    dom->minor_heap_area_end =
-         domain_minor_heap_area + minor_heap_max_bsz;
-
-    CAMLassert(dom->minor_heap_area_end <= caml_minor_heaps_end);
-  }
 }
 
 static void unreserve_minor_heaps() {
@@ -760,96 +750,54 @@ static void unreserve_minor_heaps() {
 
   caml_gc_log("unreserve_minor_heaps");
 
-  for (int i = 0; i < Max_domains; i++) {
-    struct dom_internal* dom = &all_domains[i];
-
-    CAMLassert(
-      /* this domain is not running */
-      !dom->interruptor.running
-      || (
-        /* or its minor heap must already be uninitialized */
-        dom->state != NULL
-        && dom->state->young_start == NULL
-        && dom->state->young_end == NULL
-      ));
-    /* Note: interruptor.running does not guarantee that dom->state is
-       correctly initialized, but domain initialization cannot run
-       concurrently with STW sections so we cannot observe partial
-       initialization states. */
-
-    /* uninitialize the minor heap area */
-    dom->minor_heap_area_start = dom->minor_heap_area_end = 0;
-  }
-
   size = caml_minor_heaps_end - caml_minor_heaps_start;
-  CAMLassert (Bsize_wsize(caml_minor_heap_max_wsz) * Max_domains == size);
+  CAMLassert (Bsize_wsize(caml_minor_heap_wsz) * Max_domains == size);
   caml_mem_unmap((void *) caml_minor_heaps_start, size);
 }
 
-static void stw_resize_minor_heap_reservation(caml_domain_state* domain,
+void caml_stw_resize_minor_heaps(caml_domain_state* domain,
                                        void* minor_wsz_data,
                                        int participating_count,
                                        caml_domain_state** participating) {
   barrier_status b;
-  uintnat new_minor_wsz = (uintnat) minor_wsz_data;
+  uintnat new_normalized_minor_wsz = (uintnat) minor_wsz_data;
 
-  caml_gc_log("stw_resize_minor_heap_reservation: "
+  caml_gc_log("caml_stw_resize_minor_heaps: "
               "caml_empty_minor_heap_no_major_slice_from_stw");
   caml_empty_minor_heap_no_major_slice_from_stw(domain, NULL,
-                                            participating_count, participating);
+                                        participating_count, participating);
 
-  caml_gc_log("stw_resize_minor_heap_reservation: free_minor_heap");
+  caml_gc_log("caml_stw_resize_minor_heaps: free_minor_heap");
   free_minor_heap();
 
   b = caml_global_barrier_begin ();
   if (caml_global_barrier_is_final(b)) {
     CAML_EV_BEGIN(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
-    caml_gc_log("stw_resize_minor_heap_reservation: "
+    caml_gc_log("caml_stw_resize_minor_heaps: "
                 "unreserve_minor_heaps");
 
     unreserve_minor_heaps();
-    /* new_minor_wsz is page-aligned because caml_norm_minor_heap_size has
-       been called to normalize it earlier.
-    */
-    caml_minor_heap_max_wsz = new_minor_wsz;
-    caml_gc_log("stw_resize_minor_heap_reservation: reserve_minor_heaps");
-    reserve_minor_heaps();
-    /* The call to [reserve_minor_heaps] makes a new reservation,
-       and it also updates the reservation boundaries of each domain
-       by mutating its [minor_heap_area_start{,_end}] variables.
+    caml_minor_heap_wsz = new_normalized_minor_wsz;
 
-       Thse variables are synchronized by the fact that we are inside
-       a STW section: no other domains are running in parallel, and
-       the participating domains will synchronize with this write by
-       exiting the barrier, before they read those variables in
-       [allocate_minor_heap] below. */
+    caml_gc_log("caml_stw_resize_minor_heaps: reserve_minor_heaps");
+    reserve_minor_heaps();
     CAML_EV_END(EV_DOMAIN_RESIZE_HEAP_RESERVATION);
   }
   caml_global_barrier_end(b);
 
-  caml_gc_log("stw_resize_minor_heap_reservation: "
+  caml_gc_log("caml_stw_resize_minor_heaps: "
               "allocate_minor_heap");
   /* Note: each domain allocates its own minor heap. This seems
      important to get good NUMA behavior. We don't want a single
      domain to allocate all minor heaps, which could create locality
      issues we don't understand very well. */
-  if (allocate_minor_heap(Caml_state->minor_heap_wsz) < 0) {
+  if (allocate_minor_heap(caml_minor_heap_wsz) < 0) {
     caml_fatal_error("Fatal error: No memory for minor heap");
   }
 }
 
-void caml_update_minor_heap_max(uintnat requested_wsz) {
-  caml_gc_log("Changing heap_max_wsz from %" ARCH_INTNAT_PRINTF_FORMAT
-              "u to %" ARCH_INTNAT_PRINTF_FORMAT "u.",
-              caml_minor_heap_max_wsz, requested_wsz);
-  while (requested_wsz > caml_minor_heap_max_wsz) {
-    caml_try_run_on_all_domains(
-      &stw_resize_minor_heap_reservation, (void*)requested_wsz, 0);
-  }
-  check_minor_heap();
-}
-
-void caml_init_domains(uintnat minor_heap_wsz) {
+/* caml_minor_heap_wsz must be set before calling caml_init_domains */
+void caml_init_domains() {
   int i;
 
   reserve_minor_heaps();
@@ -875,7 +823,7 @@ void caml_init_domains(uintnat minor_heap_wsz) {
     dom->backup_thread_msg = BT_INIT;
   }
 
-  create_domain(minor_heap_wsz);
+  create_domain();
   if (!domain_self) caml_fatal_error("Failed to create main domain");
   CAMLassert (domain_self->state->unique_id == 0);
 
@@ -1067,7 +1015,7 @@ static void* domain_thread_func(void* v)
   sigset_t mask = *(p->mask);
 #endif
 
-  create_domain(caml_params->init_minor_heap_wsz);
+  create_domain();
   /* this domain is now part of the STW participant set */
   p->newdom = domain_self;
 
@@ -1717,6 +1665,7 @@ static void domain_terminate (void)
      because it may be reused */
   caml_remove_generational_global_root(&domain_state->dls_root);
   caml_remove_generational_global_root(&domain_state->backtrace_last_exn);
+  free_minor_heap();
   caml_stat_free(domain_state->final_info);
   caml_stat_free(domain_state->ephe_info);
   caml_free_intern_state();

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -48,7 +48,7 @@ extern uintnat caml_allocation_policy;    /*        see freelist.c */
 extern uintnat caml_custom_major_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_ratio;   /* see custom.c */
 extern uintnat caml_custom_minor_max_bsz; /* see custom.c */
-extern uintnat caml_minor_heap_max_wsz;   /* see domain.c */
+extern uintnat caml_minor_heap_wsz;       /* see domain.c */
 
 CAMLprim value caml_gc_quick_stat(value v)
 {
@@ -127,7 +127,7 @@ CAMLprim value caml_gc_get(value v)
   CAMLlocal1 (res);
 
   res = caml_alloc_tuple (11);
-  Store_field (res, 0, Val_long (Caml_state->minor_heap_wsz));  /* s */
+  Store_field (res, 0, Val_long (caml_minor_heap_wsz));         /* s */
   Store_field (res, 2, Val_long (caml_percent_free));           /* o */
   Store_field (res, 3, Val_long (caml_params->verb_gc));        /* v */
   Store_field (res, 5, Val_long (caml_max_stack_wsize));        /* l */
@@ -198,29 +198,12 @@ CAMLprim value caml_gc_set(value v)
 
   /* Minor heap size comes last because it will trigger a minor collection
      (thus invalidating [v]) and it can raise [Out_of_memory]. */
-  newminwsz = caml_norm_minor_heap_size (Long_val (Field (v, 0)));
+  newminwsz = caml_norm_minor_heap_wsize (Long_val (Field (v, 0)));
 
-  if (newminwsz != Caml_state->minor_heap_wsz) {
+  if (newminwsz != caml_minor_heap_wsz) {
     caml_gc_message (0x20, "New minor heap size: %"
                      ARCH_INTNAT_PRINTF_FORMAT "uk words\n", newminwsz / 1024);
-  }
-
-  if (newminwsz > caml_minor_heap_max_wsz) {
-    caml_gc_log ("update minor heap max: %"
-                 ARCH_SIZET_PRINTF_FORMAT "uk words", newminwsz / 1024);
-    caml_update_minor_heap_max(newminwsz);
-  }
-  CAMLassert(newminwsz <= caml_minor_heap_max_wsz);
-  if (newminwsz != Caml_state->minor_heap_wsz) {
-    caml_gc_log ("current minor heap size: %"
-                 ARCH_SIZET_PRINTF_FORMAT "uk words",
-                 Caml_state->minor_heap_wsz / 1024);
-    caml_gc_log ("set minor heap size: %"
-                 ARCH_SIZET_PRINTF_FORMAT "uk words", newminwsz / 1024);
-    /* FIXME: when (newminwsz > caml_minor_heap_max_wsz) and
-       (newminwsz != Caml_state->minor_heap_wsz) are both true,
-       the current domain reallocates its own minor heap twice. */
-    caml_set_minor_heap_size (newminwsz);
+    caml_set_minor_heap_wsz (newminwsz);
   }
 
   CAML_EV_END(EV_EXPLICIT_GC_SET);
@@ -319,8 +302,8 @@ CAMLprim value caml_get_minor_free (value v)
 
 void caml_init_gc (void)
 {
-  caml_minor_heap_max_wsz =
-    caml_norm_minor_heap_size(caml_params->init_minor_heap_wsz);
+  caml_minor_heap_wsz =
+    caml_norm_minor_heap_wsize(caml_params->init_minor_heap_wsz);
 
   caml_max_stack_wsize = caml_params->init_max_stack_wsz;
   caml_fiber_wsz = (Stack_threshold * 2) / sizeof(value);
@@ -339,7 +322,7 @@ void caml_init_gc (void)
   #ifdef NATIVE_CODE
   caml_init_frame_descriptors();
   #endif
-  caml_init_domains(caml_params->init_minor_heap_wsz);
+  caml_init_domains();
 /*
   caml_major_heap_increment = major_incr;
   caml_percent_free = norm_pfree (percent_fr);

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -339,7 +339,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, int noexc)
   }
   CAML_EV_ALLOC(wosize);
   dom_st->allocated_words += Whsize_wosize(wosize);
-  if (dom_st->allocated_words > dom_st->minor_heap_wsz) {
+  if (dom_st->allocated_words > caml_minor_heap_wsz) {
     CAML_EV_COUNTER (EV_C_REQUEST_MAJOR_ALLOC_SHR, 1);
     caml_request_major_slice();
   }

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -119,21 +119,17 @@ extern int caml_debug_is_major(value val) {
 }
 #endif
 
-void caml_set_minor_heap_size (asize_t wsize)
+void caml_set_minor_heap_wsz(asize_t requested_wsz)
 {
-  caml_domain_state* domain_state = Caml_state;
-  struct caml_minor_tables *r = domain_state->minor_tables;
-
-  if (domain_state->young_ptr != domain_state->young_end)
-    caml_minor_collection();
-
-  if(caml_reallocate_minor_heap(wsize) < 0) {
-    caml_fatal_error("Fatal error: No memory for minor heap");
+  caml_gc_log("Changing heap_max_wsz from %" ARCH_INTNAT_PRINTF_FORMAT
+              "u to %" ARCH_INTNAT_PRINTF_FORMAT "u.",
+              caml_minor_heap_wsz, requested_wsz);
+  while (requested_wsz > caml_minor_heap_wsz) {
+    caml_try_run_on_all_domains(
+      &caml_stw_resize_minor_heaps, (void*)requested_wsz, 0);
   }
-
-  reset_minor_tables(r);
+  caml_check_minor_heap();
 }
-
 /*****************************************************************************/
 
 struct oldify_state {
@@ -813,7 +809,7 @@ static void realloc_generic_table
   CAMLassert (tbl->limit >= tbl->threshold);
 
   if (tbl->base == NULL){
-    alloc_generic_table (tbl, Caml_state->minor_heap_wsz / 8, 256,
+    alloc_generic_table (tbl, caml_minor_heap_wsz / 8, 256,
                          element_size);
   }else if (tbl->limit == tbl->threshold){
     CAML_EV_COUNTER (ev_counter_name, 1);

--- a/stdlib/gc.mli
+++ b/stdlib/gc.mli
@@ -105,9 +105,8 @@ type stat =
 type control =
   { minor_heap_size : int;
     (** The size (in words) of the minor heap.  Changing
-       this parameter will trigger a minor collection. The total size of the
-       minor heap used by this program is the sum of the heap sizes of the
-       active domains. Default: 256k. *)
+       this parameter will trigger a minor collection and change the
+       minor heap size of all domains. Default: 256k. *)
 
     major_heap_increment : int;
     (** How much to add to the major heap when increasing it. If this


### PR DESCRIPTION
Currently, every domain has its own minor heap size that it can modify within the boundary of the minor heap reservation. However, this semantics of `Gc.set` may be confusing to the user.

This PR proposes to adjust the semantics of `Gc.set` and simplify the minor heap allocation code (with the intent of keeping minor heap allocation code complexity as low as we can for the 5.00 release):

1. `Gc.set` updates the minor heap size for all domains.
2. Consequently: the minor heap size of all domains is identical. So, instead of maintaining it in `Caml_state`, we make the minor heap size global.
3. As the minor heap reservation is split into equal parts of the same size (as established in #11082), we do not need to keep track of `minor_heap_area_start` and `minor_heap_area_end` in `dom_internal`. Since access to these boundaries is not performance-critical, we can compute them from the minor heap size and domain index instead.
4. We add the missing deallocation (free / decommit) of the minor heap on `domain_terminate()` under the protection of the domain lock. This establishes the invariant that only active domains have a minor heap allocated (committed) within the minor heap reservation of all domains.

In contrast to #11082, setting a smaller minor heap size also stops the world and makes a new minor heap reservation, as we adjust the minor heap size of all domains.

As this patch implements the user-visible extension of `Gc.set` semantics for 5.00, we propose a shared `Changes` entry for #11082 and this PR.